### PR TITLE
Remove unnecessary input method from test setup

### DIFF
--- a/test/test_irb_power_assert.rb
+++ b/test/test_irb_power_assert.rb
@@ -6,33 +6,6 @@ require_relative 'helper'
 require 'stringio'
 
 class TestIRBPowerAssert < Test::Unit::TestCase
-  # Taken from https://github.com/ruby/irb/blob/ad08152c43d4309ee4dec3bbaf361ffc338c1f46/test/irb/test_cmd.rb#L8-L32, thank you!(I don't know what is this...)
-  class InputMethod < ::IRB::InputMethod
-    attr_reader :list, :line_no
-
-    def initialize(list = [])
-      super('test')
-      @line_no = 0
-      @list = list
-    end
-
-    def gets
-      @list[@line_no]&.tap { @line_no += 1 }
-    end
-
-    def eof?
-      @line_no >= @list.size
-    end
-
-    def encoding
-      Encoding.default_external
-    end
-
-    def reset
-      @line_no = 0
-    end
-  end
-
   def test_constants
     assert(IRB::PowerAssert::VERSION.frozen?)
     assert do
@@ -51,8 +24,7 @@ class TestIRBPowerAssert < Test::Unit::TestCase
     IRB.conf[:USE_SINGLELINE] = false
     IRB.conf[:VERBOSE] = false
     workspace = IRB::WorkSpace.new(self)
-    # https://github.com/ruby/irb/pull/635#discussion_r1257447968
-    irb = IRB::Irb.new(workspace, IRB::StdioInputMethod.new)
+    irb = IRB::Irb.new(workspace)
     IRB.conf[:MAIN_CONTEXT] = irb.context
 
     expected =<<~'EOD'


### PR DESCRIPTION
Since the test captures stdout directly, there is no need to use a custom input method for capturing the output.