### PR TITLE
Refine how to keep compatibility in multiple irb versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
         patterns:
           - 'DeterminateSystems*'
   - package-ecosystem: 'bundler'
+    # Do not includes '/gemfiles' or exclude irb and power_assert to test oldest dependencies also work
     directory: '/'
     schedule:
       interval: 'weekly'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
         patterns:
           - 'DeterminateSystems*'
   - package-ecosystem: 'bundler'
-    # Do not includes '/gemfiles' or exclude irb and power_assert to test oldest dependencies also work
     directory: '/'
     schedule:
       interval: 'weekly'
@@ -20,10 +19,16 @@ updates:
       rubocop-dependencies:
         patterns:
           - '*rubocop*'
+  - package-ecosystem: 'bundler'
+    directory: '/gemfiles/oldest'
+    schedule:
+      interval: 'weekly'
+    versioning-strategy: increase
+    groups:
+      dev-dependencies:
+        patterns:
+          - '*'
+    # Because of this Gemfile purpose is to test oldest dependencies also work
     ignore:
-      - dependency-name: 'rubocop'
-        versions:
-          # https://github.com/rubocop/rubocop/pull/10796
-          - '1.31.2'
-          # https://github.com/rubocop/rubocop/issues/11549
-          - '1.45.0'
+      - dependency-name: 'irb'
+      - dependency-name: 'power_assert'

--- a/.github/workflows/ci-ruby.yml
+++ b/.github/workflows/ci-ruby.yml
@@ -7,7 +7,7 @@ on:
       - '.github/workflows/ci-ruby.yml'
       - '.ruby-version'
       - '**.gemspec'
-      - 'Gemfile'
+      - '**Gemfile'
       - 'Rakefile'
       - '**.rb'
   pull_request:
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/ci-ruby.yml'
       - '.ruby-version'
       - '**.gemspec'
-      - 'Gemfile'
+      - '**Gemfile'
       - 'Rakefile'
       - '**.rb'
   schedule:
@@ -32,7 +32,10 @@ jobs:
         os: [ubuntu-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby: ['head', '3.3', '3.2']
+        gemfile: ['Gemfile', 'gemfiles/oldest/Gemfile']
     runs-on: ${{ matrix.os }}
+    env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
+      BUNDLE_GEMFILE: '${{ github.workspace }}/${{ matrix.gemfile }}'
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,7 @@ end
 group :test do
   gem 'test-unit', '~> 3.6.2'
   gem 'warning', '~> 1.3.0'
+
+  gem 'irb', '1.13.0'
+  gem 'power_assert', '2.0.3'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ group :development, :test do
 end
 
 group :development do
-  gem 'debug', '~> 1.9.2', require: false
   gem 'rubocop', '~> 1.63.4', require: false
   gem 'rubocop-rake', '~> 0.6.0', require: false
 end

--- a/gemfiles/oldest/Gemfile
+++ b/gemfiles/oldest/Gemfile
@@ -7,7 +7,6 @@ group :development, :test do
 end
 
 group :development do
-  gem 'debug', '~> 1.9.2', require: false
   gem 'rubocop', '~> 1.63.4', require: false
   gem 'rubocop-rake', '~> 0.6.0', require: false
 end

--- a/gemfiles/oldest/Gemfile
+++ b/gemfiles/oldest/Gemfile
@@ -15,6 +15,6 @@ group :test do
   gem 'test-unit', '~> 3.6.2'
   gem 'warning', '~> 1.3.0'
 
+  gem 'irb', '1.12.0'
   gem 'power_assert', '2.0.3'
-  gem 'irb', '1.4.1'
 end

--- a/gemfiles/oldest/Gemfile
+++ b/gemfiles/oldest/Gemfile
@@ -1,0 +1,21 @@
+source 'https://rubygems.org'
+
+gemspec(path: Pathname(__dir__).parent.parent)
+
+group :development, :test do
+  gem 'rake', '~> 13.2.1'
+end
+
+group :development do
+  gem 'debug', '~> 1.9.2', require: false
+  gem 'rubocop', '~> 1.63.4', require: false
+  gem 'rubocop-rake', '~> 0.6.0', require: false
+end
+
+group :test do
+  gem 'test-unit', '~> 3.6.2'
+  gem 'warning', '~> 1.3.0'
+
+  gem 'power_assert', '2.0.3'
+  gem 'irb', '1.4.1'
+end

--- a/irb-power_assert.gemspec
+++ b/irb-power_assert.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
     'rubygems_mfa_required' => 'true',
   }
 
-  gem.add_runtime_dependency 'irb', '>= 1.4.1', '< 2.0'
+  gem.add_runtime_dependency 'irb', '>= 1.12.0', '< 2.0'
   gem.add_runtime_dependency 'power_assert', '>= 2.0.3', '< 3.0'
 
   gem.required_ruby_version = '>= 3.2'

--- a/lib/irb/cmd/pa.rb
+++ b/lib/irb/cmd/pa.rb
@@ -19,7 +19,7 @@ module IRB
     end
   end
 
-  if PowerAssert.newer_irb?
+  if ::IRB::Command.respond_to?(:register)
     Command.register(:pa, PaCommand)
   else
     Command::Pa = PaCommand

--- a/lib/irb/power_assert.rb
+++ b/lib/irb/power_assert.rb
@@ -5,15 +5,6 @@
 require 'irb'
 require 'power_assert'
 
-module IRB
-  module PowerAssert
-    def self.newer_irb?
-      # This assumes irb bumps minor or major in next versions, because they do not bump in current development versions.
-      Gem::Version.create(IRB::VERSION) >= Gem::Version.create('1.13.0') || RUBY_VERSION >= '3.4'
-    end
-  end
-end
-
 module PowerAssert
   INTERNAL_LIB_DIRS[IRB::PowerAssert] = File.dirname(File.dirname(caller_locations(1, 1).first.path))
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -53,8 +53,6 @@ module TestIRBPowerAssertHelpers
   end
 
   def execute_lines(*lines, conf: {}, main: self, irb_path: nil)
-    raise unless RUBY_VERSION >= '3.4'
-
     IRB.init_config(nil)
     IRB.conf[:VERBOSE] = false
     IRB.conf[:PROMPT_MODE] = :SIMPLE

--- a/test/test_irb_power_assert.rb
+++ b/test/test_irb_power_assert.rb
@@ -35,7 +35,7 @@ class TestIRBPowerAssert < Test::Unit::TestCase
     EOD
 
     out, err = capture_output do
-      if IRB::PowerAssert.newer_irb?
+      if ::IRB::Command.respond_to?(:register)
         # Since ruby 3.4 (or newer irb gem), no need irbrc hack to realize `pa exp` instead of `pa 'exp'`
         execute_lines(%q{pa "0".class == "3".to_i.times.map {|i| i + 1 }.class})
       else
@@ -52,6 +52,6 @@ class TestIRBPowerAssert < Test::Unit::TestCase
     end
 
     assert_equal('', err)
-    assert_equal((IRB::PowerAssert.newer_irb? ? expected + "=> nil\n" : expected), out)
+    assert_equal((::IRB::Command.respond_to?(:register) ? expected + "=> nil\n" : expected), out)
   end
 end


### PR DESCRIPTION
Fixes #197

* [x] Replace predicator with `IRB::Command.register` instead of hardcoded versions
* [x] Add gem matrix CI as same as https://github.com/kachick/rspec-matchers-power_assert_matchers/pull/52
* ~[ ] (Optional) Drop to support old irb versions~ => Extract to another PR