### PR TITLE
Add E2E test in CI

### DIFF
--- a/.github/workflows/ci-ruby.yml
+++ b/.github/workflows/ci-ruby.yml
@@ -69,6 +69,10 @@ jobs:
           bundler-cache: true
       - run: mkdir -p pkg
       - run: bundle exec gem build --strict --norc --output=pkg/irb-power_assert.gem irb-power_assert.gemspec
+      - name: Make sure we can use the gem
+        run: |
+          gem install pkg/irb-power_assert.gem
+          echo 'pa (2 * 3 * 7).abs == 1010102.to_s.to_i(2)' | irb -r irb-power_assert --script -
       - name: Upload artifact
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'bundler/setup'
-
 require_relative '../lib/irb/power_assert'
 
 IRB.start

--- a/lib/irb/power_assert.rb
+++ b/lib/irb/power_assert.rb
@@ -4,10 +4,10 @@
 
 require 'irb'
 require 'power_assert'
+require_relative 'power_assert/version'
 
 module PowerAssert
   INTERNAL_LIB_DIRS[IRB::PowerAssert] = File.dirname(File.dirname(caller_locations(1, 1).first.path))
 end
 
-require_relative 'power_assert/version'
 require_relative 'cmd/pa'


### PR DESCRIPTION
v0.3.0 cannot be used

```
/home/kachick/.local/share/gem/ruby/3.3.0/gems/irb-power_assert-0.3.0/lib/irb/power_assert.rb:9:in `<module:PowerAssert>': uninitialized constant IRB::PowerAssert (NameError)

  INTERNAL_LIB_DIRS[IRB::PowerAssert] = File.dirname(File.dirname(caller_locations(1, 1).first.path)
```